### PR TITLE
add snmp monitoring of mikrtik router

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,14 @@ services:
     network_mode: host
     depends_on:
       - blackbox
+      - snmp
     # ports:
     #   - "9090:9090"
+  snmp:
+    build:
+      context: snmp/
+      dockerfile: Dockerfile
+    network_mode: host
   blackbox:
     build:
       context: blackbox/

--- a/grafana/datasource.template.yml
+++ b/grafana/datasource.template.yml
@@ -14,7 +14,7 @@ datasources:
     # <int> org id. will default to orgId 1 if not specified
     orgId: 1
     # <string> url
-    url: http://localhost:9090
+    url: http://127.0.0.1:9090
     # <string> database password, if used
     password:
     # <string> database user, if used
@@ -56,10 +56,10 @@ datasources:
     url: '$IP_TELRAAM:8081'
   - name: 'Data API'
     type: 'marcusolsson-json-datasource'
-    url: 'http://localhost:8000'
+    url: 'http://127.0.0.1:8000'
   - name: 'Timesync API'
     type: 'marcusolsson-json-datasource'
-    url: 'http://localhost:3030'
+    url: 'http://127.0.0.1:3030'
   - name: 'Telraan Postgres Replica'
     type: postgres
     url: $CLIENT2_IP:5432

--- a/grafana/provisioning/dashboards/snmp-network.json
+++ b/grafana/provisioning/dashboards/snmp-network.json
@@ -1,0 +1,237 @@
+{
+	"annotations": {
+	  "list": [
+		{
+		  "builtIn": 1,
+		  "datasource": {
+			"type": "grafana",
+			"uid": "-- Grafana --"
+		  },
+		  "enable": true,
+		  "hide": true,
+		  "iconColor": "rgba(0, 211, 255, 1)",
+		  "name": "Annotations & Alerts",
+		  "target": {
+			"limit": 100,
+			"matchAny": false,
+			"tags": [],
+			"type": "dashboard"
+		  },
+		  "type": "dashboard"
+		}
+	  ]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 0,
+	"id": 15,
+	"links": [],
+	"liveNow": false,
+	"panels": [
+	  {
+		"datasource": {
+		  "type": "prometheus",
+		  "uid": "PBFA97CFB590B2093"
+		},
+		"description": "Traffic on the mikrotik router per bridge network",
+		"fieldConfig": {
+		  "defaults": {
+			"color": {
+			  "mode": "palette-classic"
+			},
+			"custom": {
+			  "axisCenteredZero": false,
+			  "axisColorMode": "text",
+			  "axisLabel": "",
+			  "axisPlacement": "auto",
+			  "barAlignment": 0,
+			  "drawStyle": "line",
+			  "fillOpacity": 0,
+			  "gradientMode": "none",
+			  "hideFrom": {
+				"legend": false,
+				"tooltip": false,
+				"viz": false
+			  },
+			  "lineInterpolation": "linear",
+			  "lineWidth": 1,
+			  "pointSize": 5,
+			  "scaleDistribution": {
+				"type": "linear"
+			  },
+			  "showPoints": "auto",
+			  "spanNulls": false,
+			  "stacking": {
+				"group": "A",
+				"mode": "none"
+			  },
+			  "thresholdsStyle": {
+				"mode": "off"
+			  }
+			},
+			"mappings": [],
+			"thresholds": {
+			  "mode": "absolute",
+			  "steps": [
+				{
+				  "color": "green"
+				},
+				{
+				  "color": "red",
+				  "value": 80
+				}
+			  ]
+			},
+			"unit": "binBps"
+		  },
+		  "overrides": []
+		},
+		"gridPos": {
+		  "h": 9,
+		  "w": 24,
+		  "x": 0,
+		  "y": 0
+		},
+		"id": 2,
+		"options": {
+		  "legend": {
+			"calcs": [],
+			"displayMode": "list",
+			"placement": "bottom",
+			"showLegend": true
+		  },
+		  "tooltip": {
+			"mode": "single",
+			"sort": "none"
+		  }
+		},
+		"pluginVersion": "9.3.6",
+		"targets": [
+		  {
+			"datasource": {
+			  "type": "prometheus",
+			  "uid": "PBFA97CFB590B2093"
+			},
+			"editorMode": "code",
+			"expr": "rate(ifHCInOctets{ifName!~\"ether.*\"}[$__rate_interval])",
+			"legendFormat": "{{ifName}}",
+			"range": true,
+			"refId": "A"
+		  }
+		],
+		"title": "Router traffic IN",
+		"type": "timeseries"
+	  },
+	  {
+		"datasource": {
+		  "type": "prometheus",
+		  "uid": "PBFA97CFB590B2093"
+		},
+		"description": "Traffic on the mikrotik router per bridge network",
+		"fieldConfig": {
+		  "defaults": {
+			"color": {
+			  "mode": "palette-classic"
+			},
+			"custom": {
+			  "axisCenteredZero": false,
+			  "axisColorMode": "text",
+			  "axisLabel": "",
+			  "axisPlacement": "auto",
+			  "barAlignment": 0,
+			  "drawStyle": "line",
+			  "fillOpacity": 0,
+			  "gradientMode": "none",
+			  "hideFrom": {
+				"legend": false,
+				"tooltip": false,
+				"viz": false
+			  },
+			  "lineInterpolation": "linear",
+			  "lineWidth": 1,
+			  "pointSize": 5,
+			  "scaleDistribution": {
+				"type": "linear"
+			  },
+			  "showPoints": "auto",
+			  "spanNulls": false,
+			  "stacking": {
+				"group": "A",
+				"mode": "none"
+			  },
+			  "thresholdsStyle": {
+				"mode": "off"
+			  }
+			},
+			"mappings": [],
+			"thresholds": {
+			  "mode": "absolute",
+			  "steps": [
+				{
+				  "color": "green"
+				},
+				{
+				  "color": "red",
+				  "value": 80
+				}
+			  ]
+			},
+			"unit": "binBps"
+		  },
+		  "overrides": []
+		},
+		"gridPos": {
+		  "h": 9,
+		  "w": 24,
+		  "x": 0,
+		  "y": 9
+		},
+		"id": 3,
+		"options": {
+		  "legend": {
+			"calcs": [],
+			"displayMode": "list",
+			"placement": "bottom",
+			"showLegend": true
+		  },
+		  "tooltip": {
+			"mode": "single",
+			"sort": "none"
+		  }
+		},
+		"pluginVersion": "9.3.6",
+		"targets": [
+		  {
+			"datasource": {
+			  "type": "prometheus",
+			  "uid": "PBFA97CFB590B2093"
+			},
+			"editorMode": "code",
+			"expr": "rate(ifHCOutOctets{ifName!~\"ether.*\"}[$__rate_interval])",
+			"legendFormat": "{{ifName}}",
+			"range": true,
+			"refId": "A"
+		  }
+		],
+		"title": "Router traffic OUT",
+		"type": "timeseries"
+	  }
+	],
+	"refresh": "5s",
+	"schemaVersion": 37,
+	"style": "dark",
+	"tags": [],
+	"templating": {
+	  "list": []
+	},
+	"time": {
+	  "from": "now-1h",
+	  "to": "now"
+	},
+	"timepicker": {},
+	"timezone": "",
+	"title": "Network Traffic",
+	"uid": "N80PqzyVk",
+	"version": 4,
+	"weekStart": ""
+  }

--- a/prometheus/http_hosts.template.yml
+++ b/prometheus/http_hosts.template.yml
@@ -3,43 +3,4 @@
   labels:
     service: station
     name: ronny01
-- targets:
-    - $IP_PORT_RONNY02/time
-  labels:
-    service: station
-    name: ronny02
-- targets:
-    - $IP_PORT_RONNY03/time
-  labels:
-    service: station
-    name: ronny03
-- targets:
-    - $IP_PORT_RONNY04/time
-  labels:
-    service: station
-    name: ronny04
-- targets:
-    - $IP_PORT_RONNY05/time
-  labels:
-    service: station
-    name: ronny05
-- targets:
-    - $IP_PORT_RONNY06/time
-  labels:
-    service: station
-    name: ronny06
-- targets:
-    - $IP_PORT_RONNY07/time
-  labels:
-    service: station
-    name: ronny07
-- targets:
-    - $IP_PORT_TELRAAM/time
-  labels:
-    service: telraam
-    name: telraam_1
-- targets:
-    - $IP_PORT_MANUALCOUNT/time
-  labels:
-    service: manualcount
-    name: emanualcount
+

--- a/prometheus/ping_hosts.template.yml
+++ b/prometheus/ping_hosts.template.yml
@@ -5,53 +5,7 @@
     name: ronny01
     lat: 51.04199
     lon: 3.72566
-- targets:
-    - $RONNY02_IP
-  labels:
-    service: station
-    name: ronny02
-    lat: 51.04198
-    lon: 3.72610
-- targets:
-    - $RONNY03_IP
-  labels:
-    service: station
-    name: ronny03
-    lat: 51.04238
-    lon: 3.72633
-- targets:
-    - $RONNY04_IP
-  labels:
-    service: station
-    name: ronny04
-    lat: 51.04294
-    lon: 3.72636
-- targets:
-    - $RONNY05_IP
-  labels:
-    service: station
-    name: ronny05
-    lat: 51.04319
-    lon: 3.72580
-- targets:
-    - $RONNY06_IP
-  labels:
-    service: station
-    name: ronny06
-    lat: 51.04281
-    lon: 3.72565
-- targets:
-    - $RONNY07_IP
-  labels:
-    service: station
-    name: ronny07
-    lat: 51.04226
-    lon: 3.72565
-- targets:
-    - $CLIENT1_IP
-  labels:
-    service: client1
-    name: client1
+
 - targets:
     - $CLIENT2_IP
   labels:

--- a/prometheus/prometheus.template.yml
+++ b/prometheus/prometheus.template.yml
@@ -6,7 +6,7 @@ scrape_configs:
   - job_name: "prometheus"
     scrape_interval: 5s
     static_configs:
-      - targets: [ "localhost:9090" ]
+      - targets: [ "127.0.0.1:9090" ]
 
   # - job_name: telraam
   #   metrics_path: /export
@@ -17,7 +17,20 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets: [ "$TELRAAM_IP:9187" ]
-
+  - job_name: snmp
+    static_configs:
+      - targets:
+        - 172.12.10.1  # SNMP device
+    metrics_path: /snmp
+    params:
+      module: [if_mib]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9116  # The SNMP exporter's real hostname:port.
   - job_name: blackbox
     metrics_path: /probe
     params:
@@ -31,7 +44,7 @@ scrape_configs:
       - source_labels: [ __param_target ]
         target_label: instance
       - target_label: __address__
-        replacement: "localhost:9115"
+        replacement: "127.0.0.1:9115"
 
   - job_name: blackbox-ping
     metrics_path: /probe
@@ -46,20 +59,12 @@ scrape_configs:
       - source_labels: [ __param_target ]
         target_label: instance
       - target_label: __address__
-        replacement: "localhost:9115"
+        replacement: "127.0.0.1:9115"
 
   - job_name: node
     scrape_interval: 5s
     static_configs:
       - targets: [
-          '$RONNY01_IP:9100',
-          '$RONNY02_IP:9100',
-          '$RONNY03_IP:9100',
-          '$RONNY04_IP:9100',
-          '$RONNY05_IP:9100',
-          '$RONNY06_IP:9100',
-          '$RONNY07_IP:9100',
-          '$CLIENT1_IP:9100',
           '$CLIENT2_IP:9100'
         ]
 
@@ -72,4 +77,4 @@ rule_files:
 #    - scheme: http
 #      static_configs:
 #        - targets:
-#            - "localhost:9093"
+#            - "127.0.0.1:9093"

--- a/snmp/Dockerfile
+++ b/snmp/Dockerfile
@@ -1,0 +1,7 @@
+FROM prom/snmp-exporter
+
+# COPY snmp.yml       /etc/snmp_exporter/snmp.yml
+
+EXPOSE      9116
+ENTRYPOINT  [ "/bin/snmp_exporter" ]
+CMD         [ "--config.file=/etc/snmp_exporter/snmp.yml" ]

--- a/start.sh
+++ b/start.sh
@@ -31,4 +31,4 @@ envsubst < timesync/config.template.py \
          > timesync/config.py
 
 # Starting monitoring
-docker-compose up --build
+docker-compose up --build 


### PR DESCRIPTION
add network traffic dashboard with a snmp-exporter added to prometheus to show traffic in and out the different bridge networks