### PR TITLE
fix timesync container

### DIFF
--- a/timesync/Dockerfile
+++ b/timesync/Dockerfile
@@ -1,12 +1,15 @@
 FROM debian:latest
 
 RUN apt-get update && \
-	apt-get install -yqq --no-install-recommends python3-pip build-essential
+	apt-get install -yqq --no-install-recommends python3-pip python3-venv build-essential
 
 WORKDIR /app
+RUN python3 -m venv /app/venv
 ADD requirements.txt requirements.prod.txt ./
-RUN pip install -r requirements.txt
+RUN /app/venv/bin/pip install -r requirements.txt
 
 ADD . .
 
-ENTRYPOINT ["make", "prod"]
+# source: https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
+# ENTRYPOINT ["make", "prod"]
+CMD . /app/venv/bin/activate && exec make prod

--- a/timesync/requirements.txt
+++ b/timesync/requirements.txt
@@ -1,4 +1,4 @@
 requests
-Flask==2.1.0
+Flask
 gunicorn[gevent]
-greenlet>=1.0
+greenlet


### PR DESCRIPTION
The timesync container would start, but silently fail in the background surrounding werkzeug and other requests. This modifies the timesync container so the application runs in a virtual environment and is back up and running.